### PR TITLE
Refactoring tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "symfony/symfony": "^2.7 || ^3.0 || ^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^5.7 || ~6.3.0",
+    "phpunit/phpunit": "^4.8.35 || ^5.7 || ~6.3.0",
     "symfony/phpunit-bridge": "^3.3.9",
     "codeclimate/php-test-reporter": "^0.4.0",
     "composer/composer": ">=1.0.0"

--- a/tests/Pug/PugSymfonyEngineTest.php
+++ b/tests/Pug/PugSymfonyEngineTest.php
@@ -402,7 +402,7 @@ class PugSymfonyEngineTest extends KernelTestCase
         $io->setInteractive(true);
 
         self::assertTrue(PugSymfonyEngine::install(new Event('install', $composer, $io), __DIR__ . '/../project'));
-        self::assertTrue(file_exists($installedFile));
+        self::assertFileExists($installedFile);
 
         unlink($installedFile);
         $io->setPermissive(true);
@@ -426,7 +426,7 @@ class PugSymfonyEngineTest extends KernelTestCase
             'Sorry, AppKernel.php has a format we can\'t handle automatically.',
         ], $io->getLastOutput());
         clearstatcache();
-        self::assertFalse(file_exists($installedFile));
+        self::assertFileNotExists($installedFile);
 
         foreach (['/app/config/config.yml', '/app/AppKernel.php'] as $file) {
             $fs->copy(__DIR__ . '/../project' . $file, $dir . $file);
@@ -440,7 +440,7 @@ class PugSymfonyEngineTest extends KernelTestCase
             'The bundle already exists in AppKernel.php',
         ], $io->getLastOutput());
         clearstatcache();
-        self::assertTrue(file_exists($installedFile));
+        self::assertFileExists($installedFile);
 
         unlink($installedFile);
         file_put_contents($dir . '/app/config/config.yml', str_replace(
@@ -470,7 +470,7 @@ class PugSymfonyEngineTest extends KernelTestCase
             file_get_contents($dir . '/app/config/config.yml')
         );
         clearstatcache();
-        self::assertTrue(file_exists($installedFile));
+        self::assertFileExists($installedFile);
     }
 
     /**
@@ -532,7 +532,7 @@ class PugSymfonyEngineTest extends KernelTestCase
             '  bar4: biz',
             'bar: biz',
         ]), file_get_contents($dir . '/app/config/config.yml'));
-        self::assertTrue(file_exists($installedFile));
+        self::assertFileExists($installedFile);
         unlink($installedFile);
 
         file_put_contents($dir . '/app/config/config.yml', implode("\n", [
@@ -570,6 +570,6 @@ class PugSymfonyEngineTest extends KernelTestCase
             '  engines: ["twig","php"]',
             '  bar4: biz',
         ]), file_get_contents($dir . '/app/config/config.yml'));
-        self::assertFalse(file_exists($installedFile));
+        self::assertFileNotExists($installedFile);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,10 +3,3 @@
 include_once __DIR__ . '/../vendor/autoload.php';
 include_once __DIR__ . '/project/src/TestBundle/TestBundle.php';
 include_once __DIR__ . '/project/app/AppKernel.php';
-
-if (!class_exists('PHPUnit_Framework_TestCase')) {
-    class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
-    {
-        // PHPUnit compatibility
-    }
-}


### PR DESCRIPTION
I've refactored some tests using [`assertFileExists`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists) and [`assertFileNotExists`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists). Also, removed unnecessary alias for `PHPUnit_Framework_TestCase`.

I bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support the `PHPUnit\Framework\TestCase` namespace.