### PR TITLE
remove_deprecations : Fix 	User Deprecated: The "Symfony\Component\HttpKernel\Kernel::getRootDir()" method is deprecated since Symfony 4.2, use getProjectDir() instead.

### DIFF
--- a/src/Jade/JadeSymfonyEngine.php
+++ b/src/Jade/JadeSymfonyEngine.php
@@ -65,7 +65,7 @@ class JadeSymfonyEngine implements EngineInterface, InstallerInterface, HelpersH
         $container = $kernel->getContainer();
         $this->container = $container;
         $environment = $kernel->getEnvironment();
-        $appDir = $kernel->getRootDir();
+        $appDir = $kernel->getProjectDir();
         $rootDir = dirname($appDir);
         $assetsDirectories = [$appDir . '/Resources/assets'];
         $viewDirectories = [$appDir . '/Resources/views'];


### PR DESCRIPTION
This PR Addresses the deprecation that appears in Symfony console

```
User Deprecated: The "Symfony\Component\HttpKernel\Kernel::getRootDir()" method is deprecated since Symfony 4.2, use getProjectDir() instead.
```